### PR TITLE
feat: add seeders

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -4,7 +4,8 @@
     "password": "123password456",
     "database": "ac_twitter_workspace",
     "host": "127.0.0.1",
-    "dialect": "mysql"
+    "dialect": "mysql",
+    "operatorsAliases": false
   },
   "test": {
     "username": "root",
@@ -12,7 +13,8 @@
     "database": "ac_twitter_workspace_test",
     "host": "127.0.0.1",
     "dialect": "mysql",
-    "logging": false
+    "logging": false,
+    "operatorsAliases": false
   },
   "production": {
     "username": "root",

--- a/seeders/20201214081839-users-seeder.js
+++ b/seeders/20201214081839-users-seeder.js
@@ -1,0 +1,39 @@
+'use strict';
+const faker = require('faker')
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    try {
+      await queryInterface.bulkInsert('Users', [{
+        id: 1,
+        email: 'root@example.com',
+        password: '12345678',
+        role: 'admin',
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }, ...Array.from({ length: 5 }, (_, i) => ({
+        id: i + 2,
+        name: `User${i + 1}`,
+        account: `User${i + 1}`,
+        email: `user${i + 1}@example.com`,
+        password: '12345678',
+        cover: 'https://loremflickr.com/598/200/landscape/?random=' + Math.floor(Math.random() * 100),
+        avatar: 'https://loremflickr.com/140/140/people/?random=' + Math.floor(Math.random() * 100),
+        introduction: faker.lorem.text(),
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }))])
+    } catch (error) {
+      console.log(error)
+    }
+
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    try {
+      await queryInterface.bulkDelete('Users', {})
+    } catch (error) {
+      console.log(error)
+    }
+
+  }
+};

--- a/seeders/20201214090110-tweets-seeder.js
+++ b/seeders/20201214090110-tweets-seeder.js
@@ -1,0 +1,32 @@
+'use strict';
+const faker = require('faker')
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    try {
+      //each user has 10 tweets. Description length is between 5 to 15 words, and within 140 characters
+      const tweets = []
+      for (let UserId = 1; UserId <= 5; UserId++) {
+        for (let i = 1; i <= 10; i++) {
+          tweets.push({
+            id: (UserId - 1) * 10 + i,
+            UserId,
+            description: faker.lorem.sentence(Math.floor(Math.random() * 11) + 5).slice(0, 140),
+            createdAt: new Date(),
+            updatedAt: new Date()
+          })
+        }
+      }
+      await queryInterface.bulkInsert('Tweets', tweets)
+    } catch (error) {
+      console.log(error)
+    }
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    try {
+      await queryInterface.bulkDelete('Tweets', {})
+    } catch (error) {
+      console.log(error)
+    }
+  }
+};

--- a/seeders/20201214092115-replies-seeder.js
+++ b/seeders/20201214092115-replies-seeder.js
@@ -1,0 +1,33 @@
+'use strict';
+const faker = require('faker')
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    try {
+      //each tweet has 3 replies from random users
+      const replies = []
+      for (let TweetId = 1; TweetId <= 5 * 10; TweetId++) {
+        for (let i = 1; i <= 3; i++) {
+          replies.push({
+            id: (TweetId - 1) * 3 + i,
+            TweetId,
+            UserId: Math.ceil(Math.random() * 5) + 1,
+            comment: faker.lorem.text(),
+            createdAt: new Date(),
+            updatedAt: new Date()
+          })
+        }
+      }
+      await queryInterface.bulkInsert('Replies', replies)
+    } catch (error) {
+      console.log(error)
+    }
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    try {
+      await queryInterface.bulkDelete('Replies', {})
+    } catch (error) {
+      console.log(error)
+    }
+  }
+}

--- a/seeders/20201214095901-likes-seeder.js
+++ b/seeders/20201214095901-likes-seeder.js
@@ -1,0 +1,31 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    try {
+      const likes = []
+      //every user liked 1 ~ 7 tweets
+      for (let UserId = 2; UserId <= 6; UserId++) {
+        for (let i = 1; i <= Math.floor(Math.random() * 5) + 2; i++) {
+          likes.push({
+            TweetId: Math.ceil(Math.random() * 50),
+            UserId,
+            createdAt: new Date(),
+            updatedAt: new Date()
+          })
+        }
+      }
+      await queryInterface.bulkInsert('Likes', likes)
+    } catch (error) {
+      console.log(error)
+    }
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    try {
+      await queryInterface.bulkDelete('Likes', {})
+    } catch (error) {
+      console.log(error)
+    }
+  }
+};

--- a/seeders/20201214100810-followships-seeder.js
+++ b/seeders/20201214100810-followships-seeder.js
@@ -1,0 +1,40 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    try {
+      //every user has 1 ~ 5 followings and at least 1 follower
+      const followings = []
+      const followers = []
+      for (let userId = 2; userId <= 6; userId++) {
+        for (let i = 1; i <= Math.ceil(Math.random() * 4); i++) {
+          followings.push({
+            followerId: userId,
+            followingId: Math.ceil(Math.random() * 5) + 1,
+            createdAt: new Date(),
+            updatedAt: new Date()
+          })
+        }
+        // every user has at least 1 follower
+        followers.push({
+          followerId: Math.ceil(Math.random() * 5) + 1,
+          followingId: userId,
+          createdAt: new Date(),
+          updatedAt: new Date()
+        })
+      }
+      await queryInterface.bulkInsert('Followships', followings)
+      await queryInterface.bulkInsert('Followships', followers)
+    } catch (error) {
+      console.log(error)
+    }
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    try {
+      await queryInterface.bulkDelete('Followships', {})
+    } catch (error) {
+      console.log(error)
+    }
+  }
+};


### PR DESCRIPTION
- 確認model 相關測試仍可通過
- 有多加likes及followships seeder
- 新增config參數 "operatorsAliases": false  處理 "String based operators deprecated" 的issue，完整錯誤訊息如下:

 sequelize deprecated String based operators are now deprecated. Please use Symbol based operators for better security, read
more at [http://docs.sequelizejs.com/manual/tutorial/querying.html#operators node_modules\sequelize\lib\sequelize.js:245:13](http://docs.sequelizejs.com/manual/tutorial/querying.html#operators node_modules\sequelize\lib\sequelize.js:245:13)
